### PR TITLE
bugfix: fixed to remove current popup-ref at preclick

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -22,10 +22,6 @@ const App: React.FC = () => {
     });
 
     const showPopup = (feature: mapboxgl.MapboxGeoJSONFeature) => {
-      if (popupRef.current) {
-        popupRef.current.remove();
-        popupRef.current = null;
-      }
       const properties = feature.properties;
       const coordinates = (feature.geometry as any).coordinates.slice();
       const popupClass = `mapbox-promoted-popup-adid__${properties.adid}`;
@@ -66,6 +62,12 @@ const App: React.FC = () => {
           if (!image) { throw new Error('getting image failed.'); }
           map.addImage(event.id, image);
         });
+      });
+      map.on('preclick', () => {
+        if (popupRef.current) {
+          popupRef.current.remove();
+          popupRef.current = null;
+        }
       });
       map.on('click', 'promotion-layer', (event: mapboxgl.MapMouseEvent & { features?: mapboxgl.MapboxGeoJSONFeature[] | undefined; } & mapboxgl.EventData) => {
         const feature = event.features && event.features[0];

--- a/src/components/Popup/index.tsx
+++ b/src/components/Popup/index.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useEffect, useState, useImperativeHandle } from 'react';
+import mapboxgl from 'mapbox-gl';
 import ActionItem from './ActionItem';
 import MenuItem from './MenuItem';
 import PromotionTag from '../PromotionTag';

--- a/yarn.lock
+++ b/yarn.lock
@@ -9363,13 +9363,6 @@ react-dev-utils@^11.0.3:
     strip-ansi "6.0.0"
     text-table "0.2.0"
 
-react-device-detect@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/react-device-detect/-/react-device-detect-2.1.2.tgz#60abb6fa361ec4cc839469a0c4c3e9b8ea17d6b5"
-  integrity sha512-N42xttwez3ECgu4KpOL2ICesdfoz8NCBfmc1rH9FRYSjH7NmMyANPSrQ3EvAtJyj/6TzJNhrANSO38iXjCB2Ug==
-  dependencies:
-    ua-parser-js "^0.7.30"
-
 react-dom@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
@@ -11041,11 +11034,6 @@ typescript@^4.1.2:
   version "4.4.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
   integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
-
-ua-parser-js@^0.7.30:
-  version "0.7.31"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.31.tgz#649a656b191dffab4f21d5e053e27ca17cbff5c6"
-  integrity sha512-qLK/Xe9E2uzmYI3qLeOmI0tEOt+TBBQyUIAh4aAgU05FVYzeZrKUdkAZfBNVGRaHVgV0TDkdEngJSw/SyQchkQ==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
### Description
Currently it cannot show same popup twice in a row.

https://user-images.githubusercontent.com/96367403/146667095-0d574dd4-f23a-4e8d-a7f5-6b03e5b025be.mov

### Root cause
The `popupRef.current` is removed only when another promotion-layer is clicked.
When showing same popup twice in a row, the latter `showPopup` function removes remaining `popupRef.current`.

### Solution
I moved the logic of removing `popupRef.current` into `map.on('preclick', ...` function
so that it is always removed when map is clicked.
